### PR TITLE
Pybind docstrings exportmints

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -780,12 +780,18 @@ void export_mints(py::module& m)
         .def("ao_f12", normal_f12(&MintsHelper::ao_f12), "AO F12 integrals", py::arg("corr"))
         .def("ao_f12", normal_f122(&MintsHelper::ao_f12), "AO F12 integrals", 
               py::arg("corr"), py::arg("bs1"), py::arg("bs2"), py::arg("bs3"), py::arg("bs4"))
-        .def("ao_f12_scaled", normal_f12(&MintsHelper::ao_f12_scaled), "docstring") //doc's in C++ code seem incorrect, labelled as MO
-        .def("ao_f12_scaled", normal_f122(&MintsHelper::ao_f12_scaled), "docstring")
-        .def("ao_f12_squared", normal_f12(&MintsHelper::ao_f12_squared), "docstring")
-        .def("ao_f12_squared", normal_f122(&MintsHelper::ao_f12_squared), "docstring")
-        .def("ao_f12g12", &MintsHelper::ao_f12g12, "docstring")
-        .def("ao_f12_double_commutator", &MintsHelper::ao_f12_double_commutator, "docstring")
+        .def("ao_f12_scaled", normal_f12(&MintsHelper::ao_f12_scaled), 
+             "AO F12 intgerals", py::arg("corr"))
+        .def("ao_f12_scaled", normal_f122(&MintsHelper::ao_f12_scaled), 
+             "AO F12 intgerals", py::arg("corr"), py::arg("bs1"), py::arg("bs2"), py::arg("bs3"), py::arg("bs4"))
+        .def("ao_f12_squared", normal_f12(&MintsHelper::ao_f12_squared), 
+             "AO F12 squared integrals", py::arg("corr"))
+        .def("ao_f12_squared", normal_f122(&MintsHelper::ao_f12_squared)
+             "AO F12 squared integrals", py::arg("corr"), py::arg("bs1"), py::arg("bs2"), py::arg("bs3"), py::arg("bs4"))
+        .def("ao_f12g12", &MintsHelper::ao_f12g12, 
+             "AO F12G12 integrals", py::arg("corr"))
+        .def("ao_f12_double_commutator", &MintsHelper::ao_f12_double_commutator,
+             "AO F12 double commutator integrals", py::arg("corr"))
         .def("ao_3coverlap", normal_eri(&MintsHelper::ao_3coverlap), "3 Center overlap integrals")
         .def("ao_3coverlap", normal_3c(&MintsHelper::ao_3coverlap), "3 Center overalp integrals", py::arg("bs1"), py::arg("bs2"), py::arg("bs3"))
 

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -367,34 +367,34 @@ void export_mints(py::module& m)
         .def("transpose_this", &Matrix::transpose_this, "Transpose the matrix in-place")
         .def("transpose", &Matrix::transpose, "Creates a new matrix that is the transpose of this matrix")
         .def("add", matrix_one(&Matrix::add), "Adds a matrix to this matrix")
-//        .def("axpy", &Matrix::axpy, "Add to this matrix another matrix scaled by a", py::arg("a"))
+        .def("axpy", &Matrix::axpy, "Add to this matrix another matrix scaled by a", py::arg("a"), py::arg("X"))
         .def("subtract", matrix_one(&Matrix::subtract), "Substract a matrix from this matrix")
         .def("accumulate_product", matrix_two(&Matrix::accumulate_product), 
              "Multiplies two arguments and adds the result to this matrix")
-//        .def("scale", &Matrix::scale, "Scales the matrix by the floating point value a", py::arg("a"))
+        .def("scale", &Matrix::scale, "Scales the matrix by the floating point value a", py::arg("a"))
         .def("sum_of_squares", &Matrix::sum_of_squares, "Returns the sum of the squares of this matrix")
-//        .def("add_and_orthogonalize_row", &Matrix::add_and_orthogonalize_row, "Expands the row dimension by one, \
-//              and then orthogonalizes vector v against the current rows \
-//              before setting the new row to the orthogonalized copy of v", py::arg("v") )
+        .def("add_and_orthogonalize_row", &Matrix::add_and_orthogonalize_row, "Expands the row dimension by one, \
+              and then orthogonalizes vector v against the current rows \
+              before setting the new row to the orthogonalized copy of v", py::arg("v") )
         .def("rms", &Matrix::rms, "Returns the rms of this matrix")
         .def("absmax", &Matrix::absmax, "Returns the absolute maximum value")
-//        .def("scale_row", &Matrix::scale_row, "Scales row m of irrep h by a", py::arg("h"), py::arg("m"), py::arg("a"))
-//        .def("scale_column", &Matrix::scale_column, "Scales column n of irrep h by a", py::arg("h"), py::arg("n"), py::arg("a"))
- //       .def("transform", matrix_one(&Matrix::transform), "Transform this matrix with transformer", py::arg("transformer"))
- //       .def("transform", matrix_two(&Matrix::transform), "Transform A with transformer", py::arg("transformer"))
- //       .def("back_transform", matrix_one(&Matrix::back_transform), "Backtransform this with transformer", py::arg("transformer"))
- //       .def("back_transform", matrix_two(&Matrix::back_transform), "Backtransform A with transformer", py::arg("transformer"))
- //       .def("vector_dot", double_matrix_one(&Matrix::vector_dot), 
- //            "Returns the vector dot product of this with rhs", py::arg("rhs"))
-//        .def("gemm", matrix_multiply(&Matrix::gemm), 
-//             "Generalized matrix multiplication \
-//              argument transa Transpose the left matrix? \
-//              argument transb Transpose the right matrix? \
-//              argument alpha Prefactor for the matrix multiplication \
-//              argument A Left matrix \
-//              argument B Right matrix \
-//              argument beta Prefactor for the resulting matrix",
-//              py::arg("transa"),  py::arg("transb"), py::arg("alpha") ,py::arg("A"), py::arg("B"), py::arg("beta") )
+        .def("scale_row", &Matrix::scale_row, "Scales row m of irrep h by a", py::arg("h"), py::arg("m"), py::arg("a"))
+        .def("scale_column", &Matrix::scale_column, "Scales column n of irrep h by a", py::arg("h"), py::arg("n"), py::arg("a"))
+        .def("transform", matrix_one(&Matrix::transform), "Transform this matrix with transformer", py::arg("transformer"))
+        .def("transform", matrix_two(&Matrix::transform), "Transform A with transformer", py::arg("a"), py::arg("transformer"))
+        .def("back_transform", matrix_one(&Matrix::back_transform), "Backtransform this with transformer", py::arg("transformer"))
+        .def("back_transform", matrix_two(&Matrix::back_transform), "Backtransform A with transformer", py::arg("a"),  py::arg("transformer"))
+        .def("vector_dot", double_matrix_one(&Matrix::vector_dot), 
+             "Returns the vector dot product of this with rhs", py::arg("rhs"))
+        .def("gemm", matrix_multiply(&Matrix::gemm), 
+             "Generalized matrix multiplication \
+              argument transa Transpose the left matrix? \
+              argument transb Transpose the right matrix? \
+              argument alpha Prefactor for the matrix multiplication \
+              argument A Left matrix \
+              argument B Right matrix \
+              argument beta Prefactor for the resulting matrix",
+              py::arg("transa"),  py::arg("transb"), py::arg("alpha") ,py::arg("a"), py::arg("b"), py::arg("beta") )
         .def("diagonalize", matrix_diagonalize(&Matrix::diagonalize), 
              "Diagonalizes this matrix, space for the eigvectors and eigvalues must be created by caller. Only for symmetric matrices.", 
              py::arg("eigvectors"), py::arg("eigvalues"), py::arg("order") = ascending)
@@ -413,8 +413,8 @@ void export_mints(py::module& m)
         .def("general_invert", &Matrix::general_invert, "Computes the inverse of any nonsingular matrix using LU factorization")
         .def("pseudoinverse", &Matrix::pseudoinverse, "Computes the matrix which is the conditioned pseudoinverse of this matrix",
              py::arg("condition"), py::arg("nremoved"))
- //       .def("apply_denominator", matrix_one(&Matrix::apply_denominator), 
-//             "Apply matrix of denominators to this matrix", py::arg("Matrix"))
+        .def("apply_denominator", matrix_one(&Matrix::apply_denominator), 
+             "Apply matrix of denominators to this matrix", py::arg("Matrix"))
         .def("copy", matrix_one(&Matrix::copy), "Returns a copy of the matrix")
         .def("power", &Matrix::power, 
              "Takes the matrix to the alpha power with precision cutoff", py::arg("alpha"), py::arg("cutoff") = 1.0E-12)
@@ -424,34 +424,35 @@ void export_mints(py::module& m)
         // .def("triplet", &Matrix::triplet, "docstring", py::arg("A"), py::arg("B"), py::arg("C"),
         //      py::arg("transA") = false, py::arg("transB") = false, py::arg("transC") = false)
 
-  //      .def("doublet", &Matrix::doublet, 
- //            "Returns the multiplication of two matrices A and B, with options to transpose each beforehand", 
- //             py::arg("A"), py::arg("B"), py::arg("transA") = false, py::arg("transB") = false)
+//This wont compile, with and without default bools
+//        .def("doublet", &Matrix::doublet, 
+//             "Returns the multiplication of two matrices A and B, with options to transpose each beforehand", 
+//              py::arg("A"), py::arg("B"), py::arg("transA"), py::arg("transB"))
 //        .def("triplet", &Matrix::triplet, 
- //            "Returns the multiplication of three matrics A, B, and C, with options to transpose each beforehand",
- //             py::arg("A"), py::arg("B"), py::arg("C"), 
-  //            py::arg("transA") = false, py::arg("transB") = false, py::arg("transC") = false )
-//        .def("get", matrix_get3(&Matrix::get), 
-//             "Returns a single element of a matrix in subblock h, row m, col n", py::arg("h"), py::arg("m"), py::arg("n") )
-//        .def("get", matrix_get2(&Matrix::get), "Returns a single element of a matrix, row m, col n", py::arg("m"), py::arg("n"))
+//             "Returns the multiplication of three matrics A, B, and C, with options to transpose each beforehand",
+//              py::arg("A"), py::arg("B"), py::arg("C"), 
+//              py::arg("transA") = false, py::arg("transB") = false, py::arg("transC") = false )
+        .def("get", matrix_get3(&Matrix::get), 
+             "Returns a single element of a matrix in subblock h, row m, col n", py::arg("h"), py::arg("m"), py::arg("n") )
+        .def("get", matrix_get2(&Matrix::get), "Returns a single element of a matrix, row m, col n", py::arg("m"), py::arg("n"))
         .def("set", matrix_set1(&Matrix::set), "Sets every element of a matrix to val", py::arg("val"))
-//        .def("set", matrix_set3(&Matrix::set), 
-//             "Sets a single element of a matrix to val at row m, col n", py::arg("m"), py::arg("n"), py::arg("val"))
-//        .def("set", matrix_set4(&Matrix::set), "Sets a single element of a matrix, subblock h, row m, col n, with value val",
- //                                              py::arg("h"), py::arg("m"), py::arg("n"),  py::arg("val"))
+        .def("set", matrix_set3(&Matrix::set), 
+             "Sets a single element of a matrix to val at row m, col n", py::arg("m"), py::arg("n"), py::arg("val"))
+        .def("set", matrix_set4(&Matrix::set), "Sets a single element of a matrix, subblock h, row m, col n, with value val",
+                                               py::arg("h"), py::arg("m"), py::arg("n"),  py::arg("val"))
         .def("project_out", &Matrix::project_out, "docstring") //destroyed according to matrix.h file
         .def("save", matrix_save(&Matrix::save), "Saves the matrix in ASCII format to filename, as symmetry blocks or full matrix",
              py::arg("filename"), py::arg("append") = true, py::arg("saveLowerTriangle") = true, py::arg("saveSubBlocks") = false)  
         .def("load", matrix_load(&Matrix::load), 
              "Loads a block matrix from an ASCII file (see tests/mints3 for format)", py::arg("filename"))
         .def("load_mpqc", matrix_load(&Matrix::load_mpqc), "Loads a matrix from an ASCII file in MPQC format", py::arg("filename"))
-            // shouldn't this take Petite List's sotoao() function as a default argument?
-   //     .def("remove_symmetry", &Matrix::remove_symmetry, 
-    //         "Remove symmetry from a matrix A with PetiteList::sotoao()", py::arg("A"), py::arg("transformer"))
+            // should this take Petite List's sotoao() function as a default argument?
+        .def("remove_symmetry", &Matrix::remove_symmetry, 
+             "Remove symmetry from a matrix A with PetiteList::sotoao()", py::arg("a"), py::arg("transformer"))
         .def("symmetrize_gradient", &Matrix::symmetrize_gradient, 
              "Symmetrizes a gradient-like matrix (N,3) using information from a given molecule", py::arg("mol")) 
-//        .def("rotate_columns", &Matrix::rotate_columns, 
-//             "Rotates columns i and j in irrep h by angle theta", py::arg("h"), py::arg("i"), py::arg("j"), py::arg("theta"))
+        .def("rotate_columns", &Matrix::rotate_columns, 
+             "Rotates columns i and j in irrep h by angle theta", py::arg("h"), py::arg("i"), py::arg("j"), py::arg("theta"))
         .def("array_interface", [](Matrix& m) {
 
             // Build a list of NumPy views, used for the .np and .nph accessors.Vy
@@ -505,13 +506,13 @@ void export_mints(py::module& m)
 
     typedef SharedMatrix (MatrixFactory::*create_shared_matrix)();
     typedef SharedMatrix (MatrixFactory::*create_shared_matrix_name)(const std::string&);
-
+// This will also not compile
 //    py::class_<MatrixFactory, std::shared_ptr<MatrixFactory>>(m, "MatrixFactory", "Creates Matrix objects")
 //        .def("create_matrix", create_shared_matrix(&MatrixFactory::create_shared_matrix),
-//             "Returns a new matrix object with default dimensions", py::arg("symmetry") = 0)
- //       .def("create_matrix", create_shared_matrix_name(&MatrixFactory::create_shared_matrix),
+//             "Returns a new matrix object with default dimensions", py::arg("symmetry"))
+//        .def("create_matrix", create_shared_matrix_name(&MatrixFactory::create_shared_matrix),
 //             "Returns a new Matrix object named name with default dimensions", 
-//             py::arg("mat"), py::arg("name"), py::arg("symmetry") = 0);
+//              py::arg("name"), py::arg("symmetry"));
 
     py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(m, "CdSalcList", "Class for generating symmetry adapted linear combinations")
         .def("print_out", &CdSalcList::print, "Print the SALC")
@@ -793,7 +794,7 @@ void export_mints(py::module& m)
 
         // Two-electron MO and transformers
 //        .def("mo_eri", eri(&MintsHelper::mo_eri), "MO ERI Integrals. Pass appropriate MO coefficients", 
-//             py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+//             py::arg("Iso"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
 //        .def("mo_erf_eri", erf(&MintsHelper::mo_erf_eri), "MO ERFC Omega Integrals", 
 //             py::arg("omega"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
 //        .def("mo_f12", &MintsHelper::mo_f12, "MO F12 Integrals",

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -247,7 +247,8 @@ void export_mints(py::module& m)
         .def("get", vector_getitem_1(&Vector::get), "Returns a single element value located at m", py::arg("m"))
         .def("get", vector_getitem_2(&Vector::get), "Returns a single element value located at m in irrep h", py::arg("h"), py::arg("m"))
         .def("set", vector_setitem_1(&Vector::set), "Sets a single element value located at m", py::arg("m"), py::arg("val"))
-        .def("set", vector_setitem_2(&Vector::set), "Sets a single element value located at m in irrep h", py::arg("h"), py::arg("m"), py::arg("val"))
+        .def("set", vector_setitem_2(&Vector::set), 
+             "Sets a single element value located at m in irrep h", py::arg("h"), py::arg("m"), py::arg("val"))
         .def("print_out", &Vector::print_out, "Prints the vector")
         .def("scale", &Vector::scale, "Scales the elements of a vector by sc", py::arg("sc"))
         .def("dim", &Vector::dim, "Returns the dimensions of the vector per irrep h" py::arg("h"))
@@ -297,7 +298,8 @@ void export_mints(py::module& m)
     py::class_<IntVector, std::shared_ptr<IntVector>>(m, "IntVector", "docstring")
         .def(py::init<int>())
         .def("get", &IntVector::get, "Returns a single element value located at m in irrep h", py::arg("h"), py::arg("m"))
-        .def("set", int_vector_set(&IntVector::set), "Returns a single element value located at m in irrep h", py::arg("h"), py::arg("m"), py::arg("val"))
+        .def("set", int_vector_set(&IntVector::set), 
+             "Returns a single element value located at m in irrep h", py::arg("h"), py::arg("m"), py::arg("val"))
         .def("print_out", &IntVector::print_out, "Prints the vector")
         .def("dim", &IntVector::dim, "Returns the number of dimensions per irrep h", py::arg("h"))
         .def("nirrep", &IntVector::nirrep, "Returns the number of irreps");
@@ -399,7 +401,8 @@ void export_mints(py::module& m)
         .def("pseudoinverse", &Matrix::pseudoinverse, "docstring")
         .def("apply_denominator", matrix_one(&Matrix::apply_denominator), "Apply matrix of denominators to this matrix", py::arg("Matrix"))
         .def("copy", matrix_one(&Matrix::copy), "Returns a copy of the matrix")
-        .def("power", &Matrix::power, "Takes the matrix to the alpha power with precision cutoff", py::arg("alpha"), py::arg("cutoff") = 1.0E-12)
+        .def("power", &Matrix::power, 
+             "Takes the matrix to the alpha power with precision cutoff", py::arg("alpha"), py::arg("cutoff") = 1.0E-12)
 
         // .def("doublet", &Matrix::doublet, "docstring", py::arg("A"), py::arg("B"),
         //      py::arg("transA") = false, py::arg("transB") = false)
@@ -410,21 +413,27 @@ void export_mints(py::module& m)
               py::arg("A"), py::arg("B"), py::arg("transA") = false, py::arg("transB") = false)
         .def("triplet", &Matrix::triplet, "Returns the multiplication of three matrics A, B, and C, with options to transpose each beforehand",
               py::arg("A"), py::arg("B"), py::arg("C"), py::arg("transA") = false, py::arg("transB") = false, py::arg("transC") = false )
-        .def("get", matrix_get3(&Matrix::get), "Returns a single element of a matrix in subblock h, row m, col n", py::arg("h"), py::arg("m"), py::arg("n") )
+        .def("get", matrix_get3(&Matrix::get), 
+             "Returns a single element of a matrix in subblock h, row m, col n", py::arg("h"), py::arg("m"), py::arg("n") )
         .def("get", matrix_get2(&Matrix::get), "Returns a single element of a matrix, row m, col n", py::arg("m"), py::arg("n"))
         .def("set", matrix_set1(&Matrix::set), "Sets every element of a matrix to val", py::arg("val"))
-        .def("set", matrix_set3(&Matrix::set), "Sets a single element of a matrix to val at row m, col n", py::arg("m"), py::arg("n"), py::arg("val"))
+        .def("set", matrix_set3(&Matrix::set), 
+             "Sets a single element of a matrix to val at row m, col n", py::arg("m"), py::arg("n"), py::arg("val"))
         .def("set", matrix_set4(&Matrix::set), "Sets a single element of a matrix, subblock h, row m, col n, with value val",
                                                py::arg("h"), py::arg("m"), py::arg("n"),  py::arg("val"))
         .def("project_out", &Matrix::project_out, "docstring")
         .def("save", matrix_save(&Matrix::save), "Saves the matrix in ASCII format to filename, as symmetry blocks or full matrix"
              py::arg("filename"), py::arg("append") = true, py::arg("saveLowerTriangle") = true, py::arg(saveSubBlocks) = false)  
-        .def("load", matrix_load(&Matrix::load), "Loads a block matrix from an ASCII file (see tests/mints3 for format)", py::arg("filename"))
+        .def("load", matrix_load(&Matrix::load), 
+             "Loads a block matrix from an ASCII file (see tests/mints3 for format)", py::arg("filename"))
         .def("load_mpqc", matrix_load(&Matrix::load_mpqc), "Loads a matrix from an ASCII file in MPQC format", py::arg("filename"))
-            // should this take Petite List's sotoao() function as a default?
-        .def("remove_symmetry", &Matrix::remove_symmetry, "Remove symmetry from a matrix A with PetiteList::sotoao()", py::arg("A"), py::arg("transformer"))
-        .def("symmetrize_gradient", &Matrix::symmetrize_gradient, "Symmetrizes a gradient-like matrix (N,3) using information from a given molecule", py::arg("mol")) 
-        .def("rotate_columns", &Matrix::rotate_columns, "Rotates columns i and j in irrep h by angle theta", py:arg("h"), py::arg("i"), py::arg("j"), py::arg("theta"))
+            // shouldn't this take Petite List's sotoao() function as a default argument?
+        .def("remove_symmetry", &Matrix::remove_symmetry, 
+             "Remove symmetry from a matrix A with PetiteList::sotoao()", py::arg("A"), py::arg("transformer"))
+        .def("symmetrize_gradient", &Matrix::symmetrize_gradient, 
+             "Symmetrizes a gradient-like matrix (N,3) using information from a given molecule", py::arg("mol")) 
+        .def("rotate_columns", &Matrix::rotate_columns, 
+             "Rotates columns i and j in irrep h by angle theta", py:arg("h"), py::arg("i"), py::arg("j"), py::arg("theta"))
         .def("array_interface", [](Matrix& m) {
 
             // Build a list of NumPy views, used for the .np and .nph accessors.Vy
@@ -468,10 +477,12 @@ void export_mints(py::module& m)
     py::class_<Deriv, std::shared_ptr<Deriv>>(m, "Deriv", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>>())
         .def(py::init<std::shared_ptr<Wavefunction>, char, bool, bool>())
-        .def("set_tpdm_presorted", &Deriv::set_tpdm_presorted, "docstring")
-        .def("set_ignore_reference", &Deriv::set_ignore_reference, "docstring")
+        .def("set_tpdm_presorted", &Deriv::set_tpdm_presorted, 
+             "Is the TPDM already presorted? Default is False", py::arg("val") = false)
+        .def("set_ignore_reference", &Deriv::set_ignore_reference, 
+             "Ignore reference contributions to the gradient? Default is False", py::arg("val") = false)
         .def("set_deriv_density_backtransformed", &Deriv::set_deriv_density_backtransformed,
-             "docstring")
+             "Is the deriv_density already backtransformed? Default is False", py::arg("val") = false)
         .def("compute", &Deriv::compute, "docstring");
 
     typedef SharedMatrix (MatrixFactory::*create_shared_matrix)();
@@ -479,25 +490,26 @@ void export_mints(py::module& m)
 
     py::class_<MatrixFactory, std::shared_ptr<MatrixFactory>>(m, "MatrixFactory", "docstring")
         .def("create_matrix", create_shared_matrix(&MatrixFactory::create_shared_matrix),
-             "docstring")
+             "Returns a new matrix object with default dimensions", py::arg("symmetry") = 0)
         .def("create_matrix", create_shared_matrix_name(&MatrixFactory::create_shared_matrix),
-             "docstring");
+             "Returns a new Matrix object named name with default dimensions", py::arg("mat"), py::arg("name"), py::arg("symmetry") = 0);
 
     py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(m, "CdSalcList", "docstring")
         .def("print_out", &CdSalcList::print, "docstring")
-        .def("matrix", &CdSalcList::matrix, "docstring");
+        .def("matrix", &CdSalcList::matrix, "Return the SALCs")
+        .def("matrix_irrep", &CdSalcList::matrix_irrep, "Return only the SALCS in irrep h", py::arg("h"));
 
     py::class_<GaussianShell, std::shared_ptr<GaussianShell>>(m, "GaussianShell", "docstring")
         .def_property_readonly("nprimitive", py::cpp_function(&GaussianShell::nprimitive),
-                               "docstring")
+                               "The number of primitive gaussians")
         .def_property_readonly("nfunction", py::cpp_function(&GaussianShell::nfunction),
-                               "docstring")
+                               "Total number of basis functions")
         .def_property_readonly("ncartesian", py::cpp_function(&GaussianShell::ncartesian),
-                               "docstring")
-        .def_property_readonly("am", py::cpp_function(&GaussianShell::am), "docstring")
-        .def_property_readonly("amchar", py::cpp_function(&GaussianShell::amchar), "docstring")
-        .def_property_readonly("AMCHAR", py::cpp_function(&GaussianShell::AMCHAR), "docstring")
-        .def_property_readonly("ncenter", py::cpp_function(&GaussianShell::ncenter), "docstring")
+                               "Total number of basis functions if this shell was Cartesian")
+        .def_property_readonly("am", py::cpp_function(&GaussianShell::am), "The angular momentum of the given contraction")
+        .def_property_readonly("amchar", py::cpp_function(&GaussianShell::amchar), "The character symbol for the angular momentum of the given contraction")
+        .def_property_readonly("AMCHAR", py::cpp_function(&GaussianShell::AMCHAR), "The upper-case character symbol for the angular momentum of the given contraction")
+        .def_property_readonly("ncenter", py::cpp_function(&GaussianShell::ncenter), "Returns atom number this shell is on")
         .def_property("function_index", py::cpp_function(&GaussianShell::function_index),
                       py::cpp_function(&GaussianShell::set_function_index),
                       "Basis function index where this shell starts.")
@@ -508,21 +520,21 @@ void export_mints(py::module& m)
         //            primitives").
         //            add_property("coefs", &GaussianShell::coefs, "The coefficients of all the
         //            primitives").
-        def("is_cartesian", &GaussianShell::is_cartesian, "docstring")
-        .def("is_pure", &GaussianShell::is_pure, "docstring")
+        def("is_cartesian", &GaussianShell::is_cartesian, "Returns true if contraction is Cartesian")
+        .def("is_pure", &GaussianShell::is_pure, "Returns true if contraction is pure")
         .
         //            def("normalize_shell", &GaussianShell::normalize_shell, "docstring").
-        def("exp", &GaussianShell::exp, "Returns the exponent of the given primitive")
-        .def("original_coef", &GaussianShell::original_coef, "docstring")
+        def("exp", &GaussianShell::exp, "Returns the exponent of the given primitive", py::arg("prim"))
+        .def("original_coef", &GaussianShell::original_coef, "Return unnormalized coefficient of the pi'th primitive", py::arg("pi"))
         .def("erd_coef", &GaussianShell::erd_coef, "docstring")
-        .def("coef", &GaussianShell::coef, "docstring");
+        .def("coef", &GaussianShell::coef, "Return coefficient of the pi'th primitive", py::arg("pi"));
 
     py::enum_<PrimitiveType>(m, "PrimitiveType", "docstring")
         .value("Normalized", Normalized)
         .value("Unnormalized", Unnormalized)
         .export_values();
 
-    py::enum_<GaussianType>(m, "GaussianType", "docstring")
+    py::enum_<GaussianType>(m, "GaussianType", "0 if Cartesian, 1 if Pure")
         .value("Cartesian", Cartesian)
         .value("Pure", Pure)
         .export_values();
@@ -534,8 +546,8 @@ void export_mints(py::module& m)
     py::bind_vector<std::vector<ShellInfo>>(m, "BSVec");
 
     py::class_<OneBodyAOInt, std::shared_ptr<OneBodyAOInt>> pyOneBodyAOInt(m, "OneBodyAOInt",
-                                                                           "docstring");
-    pyOneBodyAOInt.def("compute_shell", &OneBodyAOInt::compute_shell, "docstring")
+                                                                           "Basis class for all one-electron integrals");
+    pyOneBodyAOInt.def("compute_shell", &OneBodyAOInt::compute_shell, "Compute integrals between basis functions in the given shell pair")
         .def_property("origin", py::cpp_function(&OneBodyAOInt::origin),
                       py::cpp_function(&OneBodyAOInt::set_origin),
                       "The origin about which the one body ints are being computed.")
@@ -557,22 +569,22 @@ void export_mints(py::module& m)
     //        add_property("basis2", &OneBodySOInt::basis2, "The basis set on center two");
 
     py::class_<OverlapInt, std::shared_ptr<OverlapInt>>(m, "OverlapInt", pyOneBodyAOInt,
-                                                        "docstring");
-    py::class_<DipoleInt, std::shared_ptr<DipoleInt>>(m, "DipoleInt", pyOneBodyAOInt, "docstring");
+                                                        "Computes overlap integrals");
+    py::class_<DipoleInt, std::shared_ptr<DipoleInt>>(m, "DipoleInt", pyOneBodyAOInt, "Computes dipole integrals");
     py::class_<QuadrupoleInt, std::shared_ptr<QuadrupoleInt>>(m, "QuadrupoleInt", pyOneBodyAOInt,
-                                                              "docstring");
+                                                              "Computes quadrupole integrals");
     py::class_<MultipoleInt, std::shared_ptr<MultipoleInt>>(m, "MultipoleInt", pyOneBodyAOInt,
-                                                            "docstring");
+                                                            "Computes arbitrary-order multipole integrals");
     py::class_<TracelessQuadrupoleInt, std::shared_ptr<TracelessQuadrupoleInt>>(
         m, "TracelessQuadrupoleInt", pyOneBodyAOInt, "docstring");
     py::class_<ElectricFieldInt, std::shared_ptr<ElectricFieldInt>>(m, "ElectricFieldInt",
-                                                                    pyOneBodyAOInt, "docstring");
+                                                                    pyOneBodyAOInt, "Computes electric field integrals");
     py::class_<KineticInt, std::shared_ptr<KineticInt>>(m, "KineticInt", pyOneBodyAOInt,
-                                                        "docstring");
+                                                        "Computes kinetic integrals");
     py::class_<PotentialInt, std::shared_ptr<PotentialInt>>(m, "PotentialInt", pyOneBodyAOInt,
-                                                            "docstring");
+                                                            "Computes potential integrals");
     py::class_<PseudospectralInt, std::shared_ptr<PseudospectralInt>>(m, "PseudospectralInt",
-                                                                      pyOneBodyAOInt, "docstring");
+                                                                      pyOneBodyAOInt, "Computes pseudospectral integrals");
     py::class_<ElectrostaticInt, std::shared_ptr<ElectrostaticInt>>(m, "ElectrostaticInt",
                                                                     pyOneBodyAOInt, "docstring");
     py::class_<NablaInt, std::shared_ptr<NablaInt>>(m, "NablaInt", pyOneBodyAOInt, "docstring");
@@ -581,13 +593,13 @@ void export_mints(py::module& m)
 
     typedef size_t (TwoBodyAOInt::*compute_shell_ints)(int, int, int, int);
     py::class_<TwoBodyAOInt, std::shared_ptr<TwoBodyAOInt>> pyTwoBodyAOInt(m, "TwoBodyAOInt",
-                                                                           "docstring");
+                                                                           "Two body integral base class");
     pyTwoBodyAOInt.def("compute_shell", compute_shell_ints(&TwoBodyAOInt::compute_shell),
-                       "docstring");  // <-- Semicolon
+                       "Compute ERIs between 4 shells");  // <-- Semicolon
 
     py::class_<TwoElectronInt, std::shared_ptr<TwoElectronInt>>(m, "TwoElectronInt", pyTwoBodyAOInt,
-                                                                "docstring")
-        .def("compute_shell", compute_shell_ints(&TwoBodyAOInt::compute_shell), "docstring");
+                                                                "Computes two-electron repulsion integrals")
+        .def("compute_shell", compute_shell_ints(&TwoBodyAOInt::compute_shell), "Compute ERIs between 4 shells");
 
     py::class_<ERI, std::shared_ptr<ERI>>(m, "ERI", pyTwoBodyAOInt, "docstring");
     py::class_<F12, std::shared_ptr<F12>>(m, "F12", pyTwoBodyAOInt, "docstring");
@@ -602,17 +614,17 @@ void export_mints(py::module& m)
 
     py::class_<AOShellCombinationsIterator, std::shared_ptr<AOShellCombinationsIterator>>(
         m, "AOShellCombinationsIterator")
-        .def_property_readonly("p", py::cpp_function(&AOShellCombinationsIterator::p), "docstring")
-        .def_property_readonly("q", py::cpp_function(&AOShellCombinationsIterator::q), "docstring")
-        .def_property_readonly("r", py::cpp_function(&AOShellCombinationsIterator::r), "docstring")
-        .def_property_readonly("s", py::cpp_function(&AOShellCombinationsIterator::s), "docstring")
+        .def_property_readonly("p", py::cpp_function(&AOShellCombinationsIterator::p), "Returns current P index")
+        .def_property_readonly("q", py::cpp_function(&AOShellCombinationsIterator::q), "Returns current Q index")
+        .def_property_readonly("r", py::cpp_function(&AOShellCombinationsIterator::r), "Returns current R index")
+        .def_property_readonly("s", py::cpp_function(&AOShellCombinationsIterator::s), "Returns current S index")
         .def("first", &AOShellCombinationsIterator::first, "docstring")
         .def("next", &AOShellCombinationsIterator::next, "docstring")
         .def("is_done", &AOShellCombinationsIterator::is_done, "docstring");
 
     py::class_<ThreeCenterOverlapInt, std::shared_ptr<ThreeCenterOverlapInt>>(
-        m, "ThreeCenterOverlapInt", "docstring")
-        .def("compute_shell", &ThreeCenterOverlapInt::compute_shell, "docstring");
+        m, "ThreeCenterOverlapInt", "Three center overalp integrals")
+        .def("compute_shell", &ThreeCenterOverlapInt::compute_shell, "Compute the integrals of the form (a|c|b)");
 
     py::class_<IntegralFactory, std::shared_ptr<IntegralFactory>>(m, "IntegralFactory", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
@@ -620,10 +632,11 @@ void export_mints(py::module& m)
         .def(py::init<std::shared_ptr<BasisSet>>())
         // def("shells_iterator", &IntegralFactory::shells_iterator_ptr,
         // py::return_value_policy<manage_new_object>(), "docstring").
-        .def("shells_iterator", &IntegralFactory::shells_iterator_ptr, "docstring")
-        .def("eri", &IntegralFactory::eri, "docstring", py::arg("deriv") = 0,
+        .def("shells_iterator", &IntegralFactory::shells_iterator_ptr, 
+             "Returns an ERI iterator object, only coded for standard ERIs")
+        .def("eri", &IntegralFactory::eri, "Returns an ERI integral object", py::arg("deriv") = 0,
              py::arg("use_shell_pairs") = true)
-        .def("f12", &IntegralFactory::f12, "docstring", py::arg("cf"), py::arg("deriv") = 0,
+        .def("f12", &IntegralFactory::f12, "Returns an f12 integral object", py::arg("cf"), py::arg("deriv") = 0,
              py::arg("use_shell_pairs") = true)
         .def("f12g12", &IntegralFactory::f12g12, "docstring", py::arg("cf"), py::arg("deriv") = 0,
              py::arg("use_shell_pairs") = true)

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -806,7 +806,7 @@ void export_mints(py::module& m)
              py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
         .def("mo_spin_eri", &MintsHelper::mo_spin_eri, "Symmetric MO Spin ERI Integrals", py::arg("C1"), py::arg("C2"))
         .def("mo_transform", &MintsHelper::mo_transform, "N^5 ao to mo transfrom, in memory",
-             py::arg("Iso"), py::arg("C1") py::arg("C2"), py::arg("C3"), py::arg("C4"))
+             py::arg("Iso"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
         .def("set_rel_basisset", &MintsHelper::set_rel_basisset, "Sets the relativistic basis set", py::arg("rel_basis"))
 
         .def("play", &MintsHelper::play, "play function");  //???

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -704,80 +704,90 @@ void export_mints(py::module& m)
         .def(py::init<std::shared_ptr<Wavefunction> >())
 
         // Options and attributes
-        .def("nbf", &MintsHelper::nbf, "docstring")
-        .def("set_print", &MintsHelper::set_print, "docstring")
-        .def("basisset", &MintsHelper::basisset, "docstring")
-        .def("sobasisset", &MintsHelper::sobasisset, "docstring")
-        .def("factory", &MintsHelper::factory, "docstring")
-        .def("cdsalcs", &MintsHelper::cdsalcs, "docstring")
-        .def("petite_list", petite_list_0(&MintsHelper::petite_list), "docstring")
-        .def("petite_list1", petite_list_1(&MintsHelper::petite_list), "docstring")
+        .def("nbf", &MintsHelper::nbf, "Returns the number of basis functions")
+        .def("set_print", &MintsHelper::set_print, "Sets the print level")
+        .def("basisset", &MintsHelper::basisset, "Returns the basis set being used")
+        .def("sobasisset", &MintsHelper::sobasisset, "Returns the SO basis set being used")
+        .def("factory", &MintsHelper::factory, "Returns the Matrix factory being used")
+        .def("cdsalcs", &MintsHelper::cdsalcs, "Returns a CdSalcList object")
+        .def("petite_list", petite_list_0(&MintsHelper::petite_list), 
+             "Returns petite list, which transforms AO basis functions to SO's") //set arguments?
+        .def("petite_list1", petite_list_1(&MintsHelper::petite_list), "docstring") //Why is this here?
 
         // Integral builders
-        .def("integral", &MintsHelper::integral, "docstring")
-        .def("integrals", &MintsHelper::integrals, "docstring")
+        .def("integral", &MintsHelper::integral, "Integral factory being used")
+        .def("integrals", &MintsHelper::integrals, "Molecular integrals")
         .def("integrals_erf", &MintsHelper::integrals_erf, "docstring")
         .def("integrals_erfc", &MintsHelper::integrals_erfc, "docstring")
-        .def("one_electron_integrals", &MintsHelper::one_electron_integrals, "docstring")
+        .def("one_electron_integrals", &MintsHelper::one_electron_integrals, "Standard one-electron integrals")
 
         // One-electron
-        .def("ao_overlap", oneelectron(&MintsHelper::ao_overlap), "docstring")
-        .def("ao_overlap", oneelectron_mixed_basis(&MintsHelper::ao_overlap), "docstring")
-        .def("so_overlap", &MintsHelper::so_overlap, "docstring")
-        .def("ao_kinetic", oneelectron(&MintsHelper::ao_kinetic), "docstring")
-        .def("ao_kinetic", oneelectron_mixed_basis(&MintsHelper::ao_kinetic), "docstring")
-        .def("so_kinetic", &MintsHelper::so_kinetic, "docstring")
-        .def("ao_potential", oneelectron(&MintsHelper::ao_potential), "docstring")
-        .def("ao_potential", oneelectron_mixed_basis(&MintsHelper::ao_potential), "docstring")
-        .def("so_potential", &MintsHelper::so_potential, "docstring")
+        .def("ao_overlap", oneelectron(&MintsHelper::ao_overlap), "AO basis overlap integrals")
+        .def("ao_overlap", oneelectron_mixed_basis(&MintsHelper::ao_overlap), "AO mixed basis overlap integrals")
+        .def("so_overlap", &MintsHelper::so_overlap, "SO basis overlap integrals")
+        .def("ao_kinetic", oneelectron(&MintsHelper::ao_kinetic), "AO basis kinetic integrals")
+        .def("ao_kinetic", oneelectron_mixed_basis(&MintsHelper::ao_kinetic), "AO mixed basis kinetic integrals")
+        .def("so_kinetic", &MintsHelper::so_kinetic, "SO basis kinetic integrals")
+        .def("ao_potential", oneelectron(&MintsHelper::ao_potential), "AO potential integrals")
+        .def("ao_potential", oneelectron_mixed_basis(&MintsHelper::ao_potential), "AO mixed basis potential integrals")
+        .def("so_potential", &MintsHelper::so_potential, "SO basis potential integrals")
         .def("ao_ecp", oneelectron(&MintsHelper::ao_ecp), "AO basis effective core potential integrals.")
         .def("ao_ecp", oneelectron_mixed_basis(&MintsHelper::ao_ecp), "AO basis effective core potential integrals.")
         .def("so_ecp", &MintsHelper::so_ecp, "SO basis effective core potential integrals.")
 
         // One-electron properties and
-        .def("ao_pvp", &MintsHelper::ao_pvp, "docstring")
-        .def("ao_dkh", &MintsHelper::ao_dkh, "docstring")
-        .def("so_dkh", &MintsHelper::so_dkh, "docstring")
-        .def("ao_dipole", &MintsHelper::ao_dipole, "docstring")
-        .def("so_dipole", &MintsHelper::so_dipole, "docstring")
-        .def("ao_quadrupole", &MintsHelper::ao_quadrupole, "docstring")
-        .def("so_quadrupole", &MintsHelper::so_quadrupole, "docstring")
-        .def("ao_traceless_quadrupole", &MintsHelper::ao_traceless_quadrupole, "docstring")
-        .def("so_traceless_quadrupole", &MintsHelper::so_traceless_quadrupole, "docstring")
-        .def("ao_nabla", &MintsHelper::ao_nabla, "docstring")
-        .def("so_nabla", &MintsHelper::so_nabla, "docstring")
-        .def("ao_angular_momentum", &MintsHelper::ao_angular_momentum, "docstring")
-        .def("so_angular_momentum", &MintsHelper::so_angular_momentum, "docstring")
+        .def("ao_pvp", &MintsHelper::ao_pvp, "AO pvp integrals")
+        .def("ao_dkh", &MintsHelper::ao_dkh, "AO dkh integrals")
+        .def("so_dkh", &MintsHelper::so_dkh, "SO dkh integrals")
+        .def("ao_dipole", &MintsHelper::ao_dipole, "Vector AO dipole integrals")
+        .def("so_dipole", &MintsHelper::so_dipole, "Vector SO dipole integrals")
+        .def("ao_quadrupole", &MintsHelper::ao_quadrupole, "Vector AO quadrupole integrals")
+        .def("so_quadrupole", &MintsHelper::so_quadrupole, "Vector SO quadrupole integrals")
+        .def("ao_traceless_quadrupole", &MintsHelper::ao_traceless_quadrupole, "Vector AO traceless quadrupole integrals")
+        .def("so_traceless_quadrupole", &MintsHelper::so_traceless_quadrupole, "Vector SO tracless quadrupole integrals")
+        .def("ao_nabla", &MintsHelper::ao_nabla, "Vector AO nabla integrals")
+        .def("so_nabla", &MintsHelper::so_nabla, "Vector SO nabla integrals")
+        .def("ao_angular_momentum", &MintsHelper::ao_angular_momentum, "Vector AO angular momentum integrals")
+        .def("so_angular_momentum", &MintsHelper::so_angular_momentum, "Vector SO angular momentum integrals")
 
         // Two-electron AO
-        .def("ao_eri", normal_eri(&MintsHelper::ao_eri), "docstring")
-        .def("ao_eri", normal_eri2(&MintsHelper::ao_eri), "docstring")
-        .def("ao_eri_shell", &MintsHelper::ao_eri_shell, "docstring")
-        .def("ao_erf_eri", &MintsHelper::ao_erf_eri, "docstring")
-        .def("ao_f12", normal_f12(&MintsHelper::ao_f12), "docstring")
-        .def("ao_f12", normal_f122(&MintsHelper::ao_f12), "docstring")
-        .def("ao_f12_scaled", normal_f12(&MintsHelper::ao_f12_scaled), "docstring")
+        .def("ao_eri", normal_eri(&MintsHelper::ao_eri), "AO ERI integrals")
+        .def("ao_eri", normal_eri2(&MintsHelper::ao_eri), "AO ERI integrals",
+              py::arg("bs1"), py::arg("bs2"), py::arg("bs3"), py::arg("bs4"))
+        .def("ao_eri_shell", &MintsHelper::ao_eri_shell, "AO ERI Shell", py::arg("M"), py::arg("N"), py::arg("P"), py::arg("Q") )
+        .def("ao_erf_eri", &MintsHelper::ao_erf_eri, "AO ERF integrals", py::arg("omega"))
+        .def("ao_f12", normal_f12(&MintsHelper::ao_f12), "AO F12 integrals", py::arg("corr"))
+        .def("ao_f12", normal_f122(&MintsHelper::ao_f12), "AO F12 integrals", 
+              py::arg("corr"), py::arg("bs1"), py::arg("bs2"), py::arg("bs3"), py::arg("bs4"))
+        .def("ao_f12_scaled", normal_f12(&MintsHelper::ao_f12_scaled), "docstring") //doc's in C++ code seem incorrect, labelled as MO..
         .def("ao_f12_scaled", normal_f122(&MintsHelper::ao_f12_scaled), "docstring")
         .def("ao_f12_squared", normal_f12(&MintsHelper::ao_f12_squared), "docstring")
         .def("ao_f12_squared", normal_f122(&MintsHelper::ao_f12_squared), "docstring")
         .def("ao_f12g12", &MintsHelper::ao_f12g12, "docstring")
         .def("ao_f12_double_commutator", &MintsHelper::ao_f12_double_commutator, "docstring")
-        .def("ao_3coverlap", normal_eri(&MintsHelper::ao_3coverlap), "docstring")
-        .def("ao_3coverlap", normal_3c(&MintsHelper::ao_3coverlap), "docstring")
+        .def("ao_3coverlap", normal_eri(&MintsHelper::ao_3coverlap), "3 Center overlap integrals")
+        .def("ao_3coverlap", normal_3c(&MintsHelper::ao_3coverlap), "3 Center overalp integrals", py::arg("bs1"), py::arg("bs2"), py::arg("bs3"))
 
 
         // Two-electron MO and transformers
-        .def("mo_eri", eri(&MintsHelper::mo_eri), "docstring")
-        .def("mo_erf_eri", erf(&MintsHelper::mo_erf_eri), "docstring")
-        .def("mo_f12", &MintsHelper::mo_f12, "docstring")
-        .def("mo_f12_squared", &MintsHelper::mo_f12_squared, "docstring")
-        .def("mo_f12g12", &MintsHelper::mo_f12g12, "docstring")
-        .def("mo_f12_double_commutator", &MintsHelper::mo_f12_double_commutator, "docstring")
-        .def("mo_spin_eri", &MintsHelper::mo_spin_eri, "docstring")
-        .def("mo_transform", &MintsHelper::mo_transform, "docstring")
-        .def("set_rel_basisset", &MintsHelper::set_rel_basisset, "docstring")
+        .def("mo_eri", eri(&MintsHelper::mo_eri), "MO ERI Integrals. Pass appropriate MO coefficients", 
+             py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+        .def("mo_erf_eri", erf(&MintsHelper::mo_erf_eri), "MO ERFC Omega Integrals", 
+             py::arg("omega"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+        .def("mo_f12", &MintsHelper::mo_f12, "MO F12 Integrals"
+             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+        .def("mo_f12_squared", &MintsHelper::mo_f12_squared, "MO F12 squared integrals"
+             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+        .def("mo_f12g12", &MintsHelper::mo_f12g12, "MO F12G12 integrals"
+             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+        .def("mo_f12_double_commutator", &MintsHelper::mo_f12_double_commutator, "MO F12 double commutator integrals"
+             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+        .def("mo_spin_eri", &MintsHelper::mo_spin_eri, "Symmetric MO Spin ERI Integrals", py::arg("C1"), py::arg("C2"))
+        .def("mo_transform", &MintsHelper::mo_transform, "N^5 ao to mo transfrom, in memory"
+             py::arg("Iso"), py::arg("C1") py::arg("C2"), py::arg("C3"), py::arg("C4"))
+        .def("set_rel_basisset", &MintsHelper::set_rel_basisset, "Sets the relativistic basis set", py::arg("rel_basis"))
 
-        .def("play", &MintsHelper::play, "docstring");
+        .def("play", &MintsHelper::play, "play function");  //???
 
     py::class_<Vector3>(m, "Vector3",
                         "Class for vectors of length three, often Cartesian coordinate vectors, "

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -784,9 +784,9 @@ void export_mints(py::module& m)
              "AO F12 intgerals", py::arg("corr"))
         .def("ao_f12_scaled", normal_f122(&MintsHelper::ao_f12_scaled), 
              "AO F12 intgerals", py::arg("corr"), py::arg("bs1"), py::arg("bs2"), py::arg("bs3"), py::arg("bs4"))
-        .def("ao_f12_squared", normal_f12(&MintsHelper::ao_f12_squared), 
+        .def("ao_f12_squared", normal_f12(&MintsHelper::ao_f12_squared),
              "AO F12 squared integrals", py::arg("corr"))
-        .def("ao_f12_squared", normal_f122(&MintsHelper::ao_f12_squared)
+        .def("ao_f12_squared", normal_f122(&MintsHelper::ao_f12_squared),
              "AO F12 squared integrals", py::arg("corr"), py::arg("bs1"), py::arg("bs2"), py::arg("bs3"), py::arg("bs4"))
         .def("ao_f12g12", &MintsHelper::ao_f12g12, 
              "AO F12G12 integrals", py::arg("corr"))

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -439,7 +439,7 @@ void export_mints(py::module& m)
              "Sets a single element of a matrix to val at row m, col n", py::arg("m"), py::arg("n"), py::arg("val"))
         .def("set", matrix_set4(&Matrix::set), "Sets a single element of a matrix, subblock h, row m, col n, with value val",
                                                py::arg("h"), py::arg("m"), py::arg("n"),  py::arg("val"))
-        .def("project_out", &Matrix::project_out, "docstring") //destroyed
+        .def("project_out", &Matrix::project_out, "docstring") //destroyed according to matrix.h file
         .def("save", matrix_save(&Matrix::save), "Saves the matrix in ASCII format to filename, as symmetry blocks or full matrix"
              py::arg("filename"), py::arg("append") = true, py::arg("saveLowerTriangle") = true, py::arg(saveSubBlocks) = false)  
         .def("load", matrix_load(&Matrix::load), 
@@ -501,7 +501,7 @@ void export_mints(py::module& m)
              "Ignore reference contributions to the gradient? Default is False", py::arg("val") = false)
         .def("set_deriv_density_backtransformed", &Deriv::set_deriv_density_backtransformed,
              "Is the deriv_density already backtransformed? Default is False", py::arg("val") = false)
-        .def("compute", &Deriv::compute, "docstring");
+        .def("compute", &Deriv::compute, "Compute the gradient");
 
     typedef SharedMatrix (MatrixFactory::*create_shared_matrix)();
     typedef SharedMatrix (MatrixFactory::*create_shared_matrix_name)(const std::string&);
@@ -513,7 +513,7 @@ void export_mints(py::module& m)
              "Returns a new Matrix object named name with default dimensions", 
              py::arg("mat"), py::arg("name"), py::arg("symmetry") = 0);
 
-    py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(m, "CdSalcList", "docstring")
+    py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(m, "CdSalcList", "Class for generating symmetry adapted linear combinations")
         .def("print_out", &CdSalcList::print, "Print the SALC")
         .def("matrix", &CdSalcList::matrix, "Return the SALCs")
         .def("matrix_irrep", &CdSalcList::matrix_irrep, "Return only the SALCS in irrep h", py::arg("h"));
@@ -1131,9 +1131,10 @@ void export_mints(py::module& m)
         .def("move_atom", &BasisSet::move_atom, "Translate a given atom by a given amount.  Does not affect the underlying molecule object.")
         .def("max_function_per_shell", &BasisSet::max_function_per_shell, "The max number of basis functions in a shell")
         .def("max_nprimitive", &BasisSet::max_nprimitive, "The max number of primitives in a shell")
-        .def_static("construct_from_pydict", &construct_basisset_from_pydict, "docstring"); 
+        .def_static("construct_from_pydict", &construct_basisset_from_pydict, "docstring"); // what is this 
 
-    py::class_<SOBasisSet, std::shared_ptr<SOBasisSet>>(m, "SOBasisSet", "docstring")
+    py::class_<SOBasisSet, std::shared_ptr<SOBasisSet>>(m, "SOBasisSet", 
+        "An SOBasis object describes the transformation from an atomic orbital basis to a symmetry orbital basis.")
         .def("petite_list", &SOBasisSet::petite_list, "Return the PetiteList object used in creating this SO basis");
 
     py::class_<ExternalPotential, std::shared_ptr<ExternalPotential>>(m, "ExternalPotential",

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -307,7 +307,7 @@ void export_mints(py::module& m)
         .value("Descending", descending)
         .export_values();
 
-    py::enum_<Molecule::GeometryUnits>(m, "GeometryUnits", "docstring")
+    py::enum_<Molecule::GeometryUnits>(m, "GeometryUnits", "The units used to define the geometry")
         .value("Angstrom", Molecule::Angstrom)
         .value("Bohr", Molecule::Bohr)
         .export_values();
@@ -412,7 +412,7 @@ void export_mints(py::module& m)
               py::arg("A"), py::arg("B"), py::arg("C"), py::arg("transA") = false, py::arg("transB") = false, py::arg("transC") = false )
         .def("get", matrix_get3(&Matrix::get), "Returns a single element of a matrix in subblock h, row m, col n", py::arg("h"), py::arg("m"), py::arg("n") )
         .def("get", matrix_get2(&Matrix::get), "Returns a single element of a matrix, row m, col n", py::arg("m"), py::arg("n"))
-        .def("set", matrix_set1(&Matrix::set), "docstring")
+        .def("set", matrix_set1(&Matrix::set), "Sets every element of a matrix to val", py::arg("val"))
         .def("set", matrix_set3(&Matrix::set), "Sets a single element of a matrix to val at row m, col n", py::arg("m"), py::arg("n"), py::arg("val"))
         .def("set", matrix_set4(&Matrix::set), "Sets a single element of a matrix, subblock h, row m, col n, with value val",
                                                py::arg("h"), py::arg("m"), py::arg("n"),  py::arg("val"))
@@ -421,8 +421,9 @@ void export_mints(py::module& m)
              py::arg("filename"), py::arg("append") = true, py::arg("saveLowerTriangle") = true, py::arg(saveSubBlocks) = false)  
         .def("load", matrix_load(&Matrix::load), "Loads a block matrix from an ASCII file (see tests/mints3 for format)", py::arg("filename"))
         .def("load_mpqc", matrix_load(&Matrix::load_mpqc), "Loads a matrix from an ASCII file in MPQC format", py::arg("filename"))
-        .def("remove_symmetry", &Matrix::remove_symmetry, "Remove symmetry from a matrix A with PetiteList::sotoao()", py::arg("A"), py::arg("transformer")) //what?
-        .def("symmetrize_gradient", &Matrix::symmetrize_gradient, "Symmetrizes a gradient-like matrix (N,3) using information from a given molecule", py::arg("mol")) //what?
+            // should this take Petite List's sotoao() function as a default?
+        .def("remove_symmetry", &Matrix::remove_symmetry, "Remove symmetry from a matrix A with PetiteList::sotoao()", py::arg("A"), py::arg("transformer"))
+        .def("symmetrize_gradient", &Matrix::symmetrize_gradient, "Symmetrizes a gradient-like matrix (N,3) using information from a given molecule", py::arg("mol")) 
         .def("rotate_columns", &Matrix::rotate_columns, "Rotates columns i and j in irrep h by angle theta", py:arg("h"), py::arg("i"), py::arg("j"), py::arg("theta"))
         .def("array_interface", [](Matrix& m) {
 

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -253,7 +253,7 @@ void export_mints(py::module& m)
              "Sets a single element value located at m in irrep h", py::arg("h"), py::arg("m"), py::arg("val"))
         .def("print_out", &Vector::print_out, "Prints the vector")
         .def("scale", &Vector::scale, "Scales the elements of a vector by sc", py::arg("sc"))
-        .def("dim", &Vector::dim, "Returns the dimensions of the vector per irrep h" py::arg("h"))
+        .def("dim", &Vector::dim, "Returns the dimensions of the vector per irrep h", py::arg("h"))
         .def("nirrep", &Vector::nirrep, "Returns the number of irreps")
         .def("array_interface", [](Vector& v) {
 
@@ -387,12 +387,12 @@ void export_mints(py::module& m)
         .def("vector_dot", double_matrix_one(&Matrix::vector_dot), 
              "Returns the vector dot product of this with rhs", py::arg("Matrix"), py::arg("rhs"))
         .def("gemm", matrix_multiply(&Matrix::gemm), 
-             "Generalized matrix multiplication 
-              argument transa Transpose the left matrix?
-              argument transb Transpose the right matrix?
-              argument alpha Prefactor for the matrix multiplication
-              argument A Left matrix
-              argument B Right matrix
+             "Generalized matrix multiplication \
+              argument transa Transpose the left matrix? \
+              argument transb Transpose the right matrix? \
+              argument alpha Prefactor for the matrix multiplication \
+              argument A Left matrix \
+              argument B Right matrix \
               argument beta Prefactor for the resulting matrix",
               py::arg("transa"),  py::arg("transb"), py::arg("alpha") ,py::arg("A"), py::arg("B"), py::arg("beta") )
         .def("diagonalize", matrix_diagonalize(&Matrix::diagonalize), 
@@ -440,8 +440,8 @@ void export_mints(py::module& m)
         .def("set", matrix_set4(&Matrix::set), "Sets a single element of a matrix, subblock h, row m, col n, with value val",
                                                py::arg("h"), py::arg("m"), py::arg("n"),  py::arg("val"))
         .def("project_out", &Matrix::project_out, "docstring") //destroyed according to matrix.h file
-        .def("save", matrix_save(&Matrix::save), "Saves the matrix in ASCII format to filename, as symmetry blocks or full matrix"
-             py::arg("filename"), py::arg("append") = true, py::arg("saveLowerTriangle") = true, py::arg(saveSubBlocks) = false)  
+        .def("save", matrix_save(&Matrix::save), "Saves the matrix in ASCII format to filename, as symmetry blocks or full matrix",
+             py::arg("filename"), py::arg("append") = true, py::arg("saveLowerTriangle") = true, py::arg("saveSubBlocks") = false)  
         .def("load", matrix_load(&Matrix::load), 
              "Loads a block matrix from an ASCII file (see tests/mints3 for format)", py::arg("filename"))
         .def("load_mpqc", matrix_load(&Matrix::load_mpqc), "Loads a matrix from an ASCII file in MPQC format", py::arg("filename"))
@@ -451,7 +451,7 @@ void export_mints(py::module& m)
         .def("symmetrize_gradient", &Matrix::symmetrize_gradient, 
              "Symmetrizes a gradient-like matrix (N,3) using information from a given molecule", py::arg("mol")) 
         .def("rotate_columns", &Matrix::rotate_columns, 
-             "Rotates columns i and j in irrep h by angle theta", py:arg("h"), py::arg("i"), py::arg("j"), py::arg("theta"))
+             "Rotates columns i and j in irrep h by angle theta", py::arg("h"), py::arg("i"), py::arg("j"), py::arg("theta"))
         .def("array_interface", [](Matrix& m) {
 
             // Build a list of NumPy views, used for the .np and .nph accessors.Vy
@@ -796,16 +796,16 @@ void export_mints(py::module& m)
              py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
         .def("mo_erf_eri", erf(&MintsHelper::mo_erf_eri), "MO ERFC Omega Integrals", 
              py::arg("omega"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("mo_f12", &MintsHelper::mo_f12, "MO F12 Integrals"
+        .def("mo_f12", &MintsHelper::mo_f12, "MO F12 Integrals",
              py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("mo_f12_squared", &MintsHelper::mo_f12_squared, "MO F12 squared integrals"
+        .def("mo_f12_squared", &MintsHelper::mo_f12_squared, "MO F12 squared integrals",
              py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("mo_f12g12", &MintsHelper::mo_f12g12, "MO F12G12 integrals"
+        .def("mo_f12g12", &MintsHelper::mo_f12g12, "MO F12G12 integrals",
              py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("mo_f12_double_commutator", &MintsHelper::mo_f12_double_commutator, "MO F12 double commutator integrals"
+        .def("mo_f12_double_commutator", &MintsHelper::mo_f12_double_commutator, "MO F12 double commutator integrals",
              py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
         .def("mo_spin_eri", &MintsHelper::mo_spin_eri, "Symmetric MO Spin ERI Integrals", py::arg("C1"), py::arg("C2"))
-        .def("mo_transform", &MintsHelper::mo_transform, "N^5 ao to mo transfrom, in memory"
+        .def("mo_transform", &MintsHelper::mo_transform, "N^5 ao to mo transfrom, in memory",
              py::arg("Iso"), py::arg("C1") py::arg("C2"), py::arg("C3"), py::arg("C4"))
         .def("set_rel_basisset", &MintsHelper::set_rel_basisset, "Sets the relativistic basis set", py::arg("rel_basis"))
 

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -636,45 +636,45 @@ void export_mints(py::module& m)
              "Returns an ERI iterator object, only coded for standard ERIs")
         .def("eri", &IntegralFactory::eri, "Returns an ERI integral object", py::arg("deriv") = 0,
              py::arg("use_shell_pairs") = true)
-        .def("f12", &IntegralFactory::f12, "Returns an f12 integral object", py::arg("cf"), py::arg("deriv") = 0,
+        .def("f12", &IntegralFactory::f12, "Returns an F12 integral object", py::arg("cf"), py::arg("deriv") = 0,
              py::arg("use_shell_pairs") = true)
-        .def("f12g12", &IntegralFactory::f12g12, "docstring", py::arg("cf"), py::arg("deriv") = 0,
+        .def("f12g12", &IntegralFactory::f12g12, "Returns an F12G12 integral object", py::arg("cf"), py::arg("deriv") = 0,
              py::arg("use_shell_pairs") = true)
-        .def("f12_double_commutator", &IntegralFactory::f12_double_commutator, "docstring",
+        .def("f12_double_commutator", &IntegralFactory::f12_double_commutator, "Returns an F12 double commutator integral object",
              py::arg("cf"), py::arg("deriv") = 0, py::arg("use_shell_pairs") = true)
-        .def("f12_squared", &IntegralFactory::f12_squared, "docstring", py::arg("cf"),
+        .def("f12_squared", &IntegralFactory::f12_squared, "Returns an F12 squared integral object", py::arg("cf"),
              py::arg("deriv") = 0, py::arg("use_shell_pairs") = true)
-        .def("erf_eri", &IntegralFactory::erf_eri, "docstring", py::arg("omega"),
+        .def("erf_eri", &IntegralFactory::erf_eri, "Returns and erf ERI integral object (omega integral)", py::arg("omega"),
              py::arg("deriv") = 0, py::arg("use_shell_pairs") = true)
-        .def("erf_complement_eri", &IntegralFactory::erf_complement_eri, "docstring",
+        .def("erf_complement_eri", &IntegralFactory::erf_complement_eri, "Returns an erf complement ERI integral object (omega integral)",
              py::arg("omega"), py::arg("deriv") = 0, py::arg("use_shell_pairs") = true)
-        .def("ao_overlap", &IntegralFactory::ao_overlap, "docstring", py::arg("deriv") = 0)
-        .def("so_overlap", &IntegralFactory::so_overlap, "docstring", py::arg("deriv") = 0)
-        .def("ao_dipole", &IntegralFactory::ao_dipole, "docstring", py::arg("deriv") = 0)
-        .def("so_dipole", &IntegralFactory::so_dipole, "docstring", py::arg("deriv") = 0)
-        .def("ao_kinetic", &IntegralFactory::ao_kinetic, "docstring", py::arg("deriv") = 0)
-        .def("so_kinetic", &IntegralFactory::so_kinetic, "docstring", py::arg("deriv") = 0)
-        .def("ao_potential", &IntegralFactory::ao_potential, "docstring", py::arg("deriv") = 0)
-        .def("so_potential", &IntegralFactory::so_potential, "docstring", py::arg("deriv") = 0)
-        .def("ao_pseudospectral", &IntegralFactory::ao_pseudospectral, "docstring",
+        .def("ao_overlap", &IntegralFactory::ao_overlap, "Returns a OneBodyInt that computes the overlap integrals", py::arg("deriv") = 0)
+        .def("so_overlap", &IntegralFactory::so_overlap, "Returns a OneBodyInt that computes the overlap integrals", py::arg("deriv") = 0)
+        .def("ao_dipole", &IntegralFactory::ao_dipole, "Returns a OneBodyInt that computes the dipole integrals", py::arg("deriv") = 0)
+        .def("so_dipole", &IntegralFactory::so_dipole, "Returns a OneBodyInt that computes the dipole integrals", py::arg("deriv") = 0)
+        .def("ao_kinetic", &IntegralFactory::ao_kinetic, "Returns a OneBodyInt that computes the kinetic integrals", py::arg("deriv") = 0)
+        .def("so_kinetic", &IntegralFactory::so_kinetic, "Returns a OneBodyInt that computes the kinteic integrals", py::arg("deriv") = 0)
+        .def("ao_potential", &IntegralFactory::ao_potential, "Returns a OneBodyInt that computes the nuclear attraction integral", py::arg("deriv") = 0)
+        .def("so_potential", &IntegralFactory::so_potential, "Returns a OneBody Int that computes the nuclear attraction integral", py::arg("deriv") = 0)
+        .def("ao_pseudospectral", &IntegralFactory::ao_pseudospectral, "Returns a OneBodyInt that computes the pseudospectral grid integrals",
              py::arg("deriv") = 0)
-        .def("so_pseudospectral", &IntegralFactory::so_pseudospectral, "docstring",
+        .def("so_pseudospectral", &IntegralFactory::so_pseudospectral, "Returns a OneBodyInt that computes the pseudospectral grid integrals",
              py::arg("deriv") = 0)
-        .def("ao_nabla", &IntegralFactory::ao_nabla, "docstring", py::arg("deriv") = 0)
-        .def("so_nabla", &IntegralFactory::so_nabla, "docstring", py::arg("deriv") = 0)
-        .def("ao_angular_momentum", &IntegralFactory::ao_angular_momentum, "docstring",
+        .def("ao_nabla", &IntegralFactory::ao_nabla, "Returns a OneBodyInt that computes the nabla integral", py::arg("deriv") = 0)
+        .def("so_nabla", &IntegralFactory::so_nabla, "Returns a OneBodyInt that computes the nabla integral", py::arg("deriv") = 0)
+        .def("ao_angular_momentum", &IntegralFactory::ao_angular_momentum, "Returns a OneBodyInt that computes the angular momentum integral",
              py::arg("deriv") = 0)
-        .def("so_angular_momentum", &IntegralFactory::so_angular_momentum, "docstring",
+        .def("so_angular_momentum", &IntegralFactory::so_angular_momentum, "Returns a OneBodyInt that computes the angular momentum integral",
              py::arg("deriv") = 0)
-        .def("ao_quadrupole", &IntegralFactory::ao_quadrupole, "docstring")
-        .def("so_quadrupole", &IntegralFactory::so_quadrupole, "docstring")
-        .def("ao_multipoles", &IntegralFactory::ao_multipoles, "docstring", py::arg("order"))
-        .def("so_multipoles", &IntegralFactory::so_multipoles, "docstring", py::arg("order"))
-        .def("ao_traceless_quadrupole", &IntegralFactory::ao_traceless_quadrupole, "docstring")
-        .def("so_traceless_quadrupole", &IntegralFactory::so_traceless_quadrupole, "docstring")
-        .def("electric_field", &IntegralFactory::electric_field, "docstring")
-        .def("electrostatic", &IntegralFactory::electrostatic, "docstring")
-        .def("overlap_3c", &IntegralFactory::overlap_3c, "docstring");
+        .def("ao_quadrupole", &IntegralFactory::ao_quadrupole, "Returns a OneBodyInt that computes the quadrupole integral")
+        .def("so_quadrupole", &IntegralFactory::so_quadrupole, "Returns a OneBodyInt that computes the quadrupole integral")
+        .def("ao_multipoles", &IntegralFactory::ao_multipoles, "Returns a OneBodyInt that computes arbitrary-order multipole integrals", py::arg("order"))
+        .def("so_multipoles", &IntegralFactory::so_multipoles, "Returns a OneBodyInt that computes arbitrary-order multipole integrals", py::arg("order"))
+        .def("ao_traceless_quadrupole", &IntegralFactory::ao_traceless_quadrupole, "Returns a OneBodyInt that computes the traceless quadrupole integral")
+        .def("so_traceless_quadrupole", &IntegralFactory::so_traceless_quadrupole, "Returns a OneBodyInt that computes the traceless quadrupole integral")
+        .def("electric_field", &IntegralFactory::electric_field, "Returns a OneBodyInt that computes the electric field")
+        .def("electrostatic", &IntegralFactory::electrostatic, "Returns a OneBodyInt that computes the point electrostatic potential")
+        .def("overlap_3c", &IntegralFactory::overlap_3c, "Returns a OneBodyInt that computes the 3 center overlap integral");
 
     typedef std::shared_ptr<PetiteList>(MintsHelper::*petite_list_0)() const;
     typedef std::shared_ptr<PetiteList>(MintsHelper::*petite_list_1)(bool) const;

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -220,7 +220,7 @@ void export_mints(py::module& m)
     typedef void (Vector::*vector_setitem_n)(const py::tuple&, double);
     typedef double (Vector::*vector_getitem_n)(const py::tuple&);
 
-    py::class_<Dimension>(m, "Dimension", "docstring")
+    py::class_<Dimension>(m, "Dimension", "Initialilzes and defines Dimension Objects")
         .def(py::init<int>())
         .def(py::init<int, const std::string&>())
         .def(py::init<const std::vector<int>&>())
@@ -418,13 +418,6 @@ void export_mints(py::module& m)
         .def("copy", matrix_one(&Matrix::copy), "Returns a copy of the matrix")
         .def("power", &Matrix::power, 
              "Takes the matrix to the alpha power with precision cutoff", py::arg("alpha"), py::arg("cutoff") = 1.0E-12)
-
-        // .def("doublet", &Matrix::doublet, "docstring", py::arg("A"), py::arg("B"),
-        //      py::arg("transA") = false, py::arg("transB") = false)
-        // .def("triplet", &Matrix::triplet, "docstring", py::arg("A"), py::arg("B"), py::arg("C"),
-        //      py::arg("transA") = false, py::arg("transB") = false, py::arg("transC") = false)
-
-//doublet and triplet require def_static since the functions are static type in C++
         .def_static("doublet", &Matrix::doublet, 
              "Returns the multiplication of two matrices A and B, with options to transpose each beforehand", 
               py::arg("A"), py::arg("B"), py::arg("transA") = false, py::arg("transB") = false)
@@ -440,7 +433,8 @@ void export_mints(py::module& m)
              "Sets a single element of a matrix to val at row m, col n", py::arg("m"), py::arg("n"), py::arg("val"))
         .def("set", matrix_set4(&Matrix::set), "Sets a single element of a matrix, subblock h, row m, col n, with value val",
                                                py::arg("h"), py::arg("m"), py::arg("n"),  py::arg("val"))
-        .def("project_out", &Matrix::project_out, "docstring") //destroyed according to matrix.h file
+        //destroyed according to matrix.h file
+        //.def("project_out", &Matrix::project_out, "docstring") 
         .def("save", matrix_save(&Matrix::save), "Saves the matrix in ASCII format to filename, as symmetry blocks or full matrix",
              py::arg("filename"), py::arg("append") = true, py::arg("saveLowerTriangle") = true, py::arg("saveSubBlocks") = false)  
         .def("load", matrix_load(&Matrix::load), 
@@ -643,7 +637,7 @@ void export_mints(py::module& m)
         .def_property_readonly("r", py::cpp_function(&AOShellCombinationsIterator::r), "Returns current R index")
         .def_property_readonly("s", py::cpp_function(&AOShellCombinationsIterator::s), "Returns current S index")
         .def("first", &AOShellCombinationsIterator::first, "docstring")
-        .def("next", &AOShellCombinationsIterator::next, "docstring") // not documented C++ side
+        .def("next", &AOShellCombinationsIterator::next, "docstring") //these are not documented C++ side
         .def("is_done", &AOShellCombinationsIterator::is_done, "docstring");
 
     py::class_<ThreeCenterOverlapInt, std::shared_ptr<ThreeCenterOverlapInt>>(
@@ -736,7 +730,10 @@ void export_mints(py::module& m)
         .def("cdsalcs", &MintsHelper::cdsalcs, "Returns a CdSalcList object")
         .def("petite_list", petite_list_0(&MintsHelper::petite_list), 
              "Returns petite list, which transforms AO basis functions to SO's") 
-        .def("petite_list1", petite_list_1(&MintsHelper::petite_list), "docstring") //What is this?
+        .def("petite_list1", petite_list_1(&MintsHelper::petite_list), 
+             "Returns petite list which transforms AO basis functions to SO's, \
+              setting argument to true is for Cartesian basis, false is for Spherical Harmonic basis", 
+              py::arg("include_pure_transform")) 
 
         // Integral builders
         .def("integral", &MintsHelper::integral, "Integral factory being used")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -366,35 +366,35 @@ void export_mints(py::module& m)
 
         .def("transpose_this", &Matrix::transpose_this, "Transpose the matrix in-place")
         .def("transpose", &Matrix::transpose, "Creates a new matrix that is the transpose of this matrix")
-        .def("add", matrix_one(&Matrix::add), "Adds a matrix to this matrix", py::arg("Matrix"))
-        .def("axpy", &Matrix::axpy, "Add to this matrix another matrix scaled by a", py::arg("a"), py::arg("X"))
-        .def("subtract", matrix_one(&Matrix::subtract), "Substract a matrix from this matrix", py::arg("Matrix"))
+        .def("add", matrix_one(&Matrix::add), "Adds a matrix to this matrix")
+//        .def("axpy", &Matrix::axpy, "Add to this matrix another matrix scaled by a", py::arg("a"))
+        .def("subtract", matrix_one(&Matrix::subtract), "Substract a matrix from this matrix")
         .def("accumulate_product", matrix_two(&Matrix::accumulate_product), 
-             "Multiplies two arguments and adds the result to this matrix", py::arg("Matrix"), py::arg("Matrix"))
-        .def("scale", &Matrix::scale, "Scales the matrix by the floating point value a", py::arg("a"))
+             "Multiplies two arguments and adds the result to this matrix")
+//        .def("scale", &Matrix::scale, "Scales the matrix by the floating point value a", py::arg("a"))
         .def("sum_of_squares", &Matrix::sum_of_squares, "Returns the sum of the squares of this matrix")
-        .def("add_and_orthogonalize_row", &Matrix::add_and_orthogonalize_row, "Expands the row dimension by one, \
-              and then orthogonalizes vector v against the current rows \
-              before setting the new row to the orthogonalized copy of v", py::arg("v") )
+//        .def("add_and_orthogonalize_row", &Matrix::add_and_orthogonalize_row, "Expands the row dimension by one, \
+//              and then orthogonalizes vector v against the current rows \
+//              before setting the new row to the orthogonalized copy of v", py::arg("v") )
         .def("rms", &Matrix::rms, "Returns the rms of this matrix")
         .def("absmax", &Matrix::absmax, "Returns the absolute maximum value")
-        .def("scale_row", &Matrix::scale_row, "Scales row m of irrep h by a", py::arg("h"), py::arg("m"), py::arg("a"))
-        .def("scale_column", &Matrix::scale_column, "Scales column n of irrep h by a", py::arg("h"), py::arg("n"), py::arg("a"))
-        .def("transform", matrix_one(&Matrix::transform), "Transform this matrix with transformer", py::arg("transformer"))
-        .def("transform", matrix_two(&Matrix::transform), "Transform A with transformer", py::arg("A"), py::arg("transformer"))
-        .def("back_transform", matrix_one(&Matrix::back_transform), "Backtransform this with transformer", py::arg("transformer"))
-        .def("back_transform", matrix_two(&Matrix::back_transform), "Backtransform A with transformer", py::arg("A"), py::arg("transformer"))
-        .def("vector_dot", double_matrix_one(&Matrix::vector_dot), 
-             "Returns the vector dot product of this with rhs", py::arg("Matrix"), py::arg("rhs"))
-        .def("gemm", matrix_multiply(&Matrix::gemm), 
-             "Generalized matrix multiplication \
-              argument transa Transpose the left matrix? \
-              argument transb Transpose the right matrix? \
-              argument alpha Prefactor for the matrix multiplication \
-              argument A Left matrix \
-              argument B Right matrix \
-              argument beta Prefactor for the resulting matrix",
-              py::arg("transa"),  py::arg("transb"), py::arg("alpha") ,py::arg("A"), py::arg("B"), py::arg("beta") )
+//        .def("scale_row", &Matrix::scale_row, "Scales row m of irrep h by a", py::arg("h"), py::arg("m"), py::arg("a"))
+//        .def("scale_column", &Matrix::scale_column, "Scales column n of irrep h by a", py::arg("h"), py::arg("n"), py::arg("a"))
+ //       .def("transform", matrix_one(&Matrix::transform), "Transform this matrix with transformer", py::arg("transformer"))
+ //       .def("transform", matrix_two(&Matrix::transform), "Transform A with transformer", py::arg("transformer"))
+ //       .def("back_transform", matrix_one(&Matrix::back_transform), "Backtransform this with transformer", py::arg("transformer"))
+ //       .def("back_transform", matrix_two(&Matrix::back_transform), "Backtransform A with transformer", py::arg("transformer"))
+ //       .def("vector_dot", double_matrix_one(&Matrix::vector_dot), 
+ //            "Returns the vector dot product of this with rhs", py::arg("rhs"))
+//        .def("gemm", matrix_multiply(&Matrix::gemm), 
+//             "Generalized matrix multiplication \
+//              argument transa Transpose the left matrix? \
+//              argument transb Transpose the right matrix? \
+//              argument alpha Prefactor for the matrix multiplication \
+//              argument A Left matrix \
+//              argument B Right matrix \
+//              argument beta Prefactor for the resulting matrix",
+//              py::arg("transa"),  py::arg("transb"), py::arg("alpha") ,py::arg("A"), py::arg("B"), py::arg("beta") )
         .def("diagonalize", matrix_diagonalize(&Matrix::diagonalize), 
              "Diagonalizes this matrix, space for the eigvectors and eigvalues must be created by caller. Only for symmetric matrices.", 
              py::arg("eigvectors"), py::arg("eigvalues"), py::arg("order") = ascending)
@@ -411,10 +411,10 @@ void export_mints(py::module& m)
         .def("schmidt", &Matrix::schmidt, "Calls the libqt schmidt function")
         .def("invert", &Matrix::invert, "Computes the inverse of a real symmetric positive definite matrix")
         .def("general_invert", &Matrix::general_invert, "Computes the inverse of any nonsingular matrix using LU factorization")
-        .def("pseudoinverse", &Matrix::pseudoinverse, "Computes the matrix which is the conditioned pseudoinvers of this matrix",
+        .def("pseudoinverse", &Matrix::pseudoinverse, "Computes the matrix which is the conditioned pseudoinverse of this matrix",
              py::arg("condition"), py::arg("nremoved"))
-        .def("apply_denominator", matrix_one(&Matrix::apply_denominator), 
-             "Apply matrix of denominators to this matrix", py::arg("Matrix"))
+ //       .def("apply_denominator", matrix_one(&Matrix::apply_denominator), 
+//             "Apply matrix of denominators to this matrix", py::arg("Matrix"))
         .def("copy", matrix_one(&Matrix::copy), "Returns a copy of the matrix")
         .def("power", &Matrix::power, 
              "Takes the matrix to the alpha power with precision cutoff", py::arg("alpha"), py::arg("cutoff") = 1.0E-12)
@@ -424,21 +424,21 @@ void export_mints(py::module& m)
         // .def("triplet", &Matrix::triplet, "docstring", py::arg("A"), py::arg("B"), py::arg("C"),
         //      py::arg("transA") = false, py::arg("transB") = false, py::arg("transC") = false)
 
-        .def("doublet", &Matrix::doublet, 
-             "Returns the multiplication of two matrices A and B, with options to transpose each beforehand", 
-              py::arg("A"), py::arg("B"), py::arg("transA") = false, py::arg("transB") = false)
-        .def("triplet", &Matrix::triplet, 
-             "Returns the multiplication of three matrics A, B, and C, with options to transpose each beforehand",
-              py::arg("A"), py::arg("B"), py::arg("C"), 
-              py::arg("transA") = false, py::arg("transB") = false, py::arg("transC") = false )
-        .def("get", matrix_get3(&Matrix::get), 
-             "Returns a single element of a matrix in subblock h, row m, col n", py::arg("h"), py::arg("m"), py::arg("n") )
-        .def("get", matrix_get2(&Matrix::get), "Returns a single element of a matrix, row m, col n", py::arg("m"), py::arg("n"))
+  //      .def("doublet", &Matrix::doublet, 
+ //            "Returns the multiplication of two matrices A and B, with options to transpose each beforehand", 
+ //             py::arg("A"), py::arg("B"), py::arg("transA") = false, py::arg("transB") = false)
+//        .def("triplet", &Matrix::triplet, 
+ //            "Returns the multiplication of three matrics A, B, and C, with options to transpose each beforehand",
+ //             py::arg("A"), py::arg("B"), py::arg("C"), 
+  //            py::arg("transA") = false, py::arg("transB") = false, py::arg("transC") = false )
+//        .def("get", matrix_get3(&Matrix::get), 
+//             "Returns a single element of a matrix in subblock h, row m, col n", py::arg("h"), py::arg("m"), py::arg("n") )
+//        .def("get", matrix_get2(&Matrix::get), "Returns a single element of a matrix, row m, col n", py::arg("m"), py::arg("n"))
         .def("set", matrix_set1(&Matrix::set), "Sets every element of a matrix to val", py::arg("val"))
-        .def("set", matrix_set3(&Matrix::set), 
-             "Sets a single element of a matrix to val at row m, col n", py::arg("m"), py::arg("n"), py::arg("val"))
-        .def("set", matrix_set4(&Matrix::set), "Sets a single element of a matrix, subblock h, row m, col n, with value val",
-                                               py::arg("h"), py::arg("m"), py::arg("n"),  py::arg("val"))
+//        .def("set", matrix_set3(&Matrix::set), 
+//             "Sets a single element of a matrix to val at row m, col n", py::arg("m"), py::arg("n"), py::arg("val"))
+//        .def("set", matrix_set4(&Matrix::set), "Sets a single element of a matrix, subblock h, row m, col n, with value val",
+ //                                              py::arg("h"), py::arg("m"), py::arg("n"),  py::arg("val"))
         .def("project_out", &Matrix::project_out, "docstring") //destroyed according to matrix.h file
         .def("save", matrix_save(&Matrix::save), "Saves the matrix in ASCII format to filename, as symmetry blocks or full matrix",
              py::arg("filename"), py::arg("append") = true, py::arg("saveLowerTriangle") = true, py::arg("saveSubBlocks") = false)  
@@ -446,12 +446,12 @@ void export_mints(py::module& m)
              "Loads a block matrix from an ASCII file (see tests/mints3 for format)", py::arg("filename"))
         .def("load_mpqc", matrix_load(&Matrix::load_mpqc), "Loads a matrix from an ASCII file in MPQC format", py::arg("filename"))
             // shouldn't this take Petite List's sotoao() function as a default argument?
-        .def("remove_symmetry", &Matrix::remove_symmetry, 
-             "Remove symmetry from a matrix A with PetiteList::sotoao()", py::arg("A"), py::arg("transformer"))
+   //     .def("remove_symmetry", &Matrix::remove_symmetry, 
+    //         "Remove symmetry from a matrix A with PetiteList::sotoao()", py::arg("A"), py::arg("transformer"))
         .def("symmetrize_gradient", &Matrix::symmetrize_gradient, 
              "Symmetrizes a gradient-like matrix (N,3) using information from a given molecule", py::arg("mol")) 
-        .def("rotate_columns", &Matrix::rotate_columns, 
-             "Rotates columns i and j in irrep h by angle theta", py::arg("h"), py::arg("i"), py::arg("j"), py::arg("theta"))
+//        .def("rotate_columns", &Matrix::rotate_columns, 
+//             "Rotates columns i and j in irrep h by angle theta", py::arg("h"), py::arg("i"), py::arg("j"), py::arg("theta"))
         .def("array_interface", [](Matrix& m) {
 
             // Build a list of NumPy views, used for the .np and .nph accessors.Vy
@@ -506,12 +506,12 @@ void export_mints(py::module& m)
     typedef SharedMatrix (MatrixFactory::*create_shared_matrix)();
     typedef SharedMatrix (MatrixFactory::*create_shared_matrix_name)(const std::string&);
 
-    py::class_<MatrixFactory, std::shared_ptr<MatrixFactory>>(m, "MatrixFactory", "Creates Matrix objects")
-        .def("create_matrix", create_shared_matrix(&MatrixFactory::create_shared_matrix),
-             "Returns a new matrix object with default dimensions", py::arg("symmetry") = 0)
-        .def("create_matrix", create_shared_matrix_name(&MatrixFactory::create_shared_matrix),
-             "Returns a new Matrix object named name with default dimensions", 
-             py::arg("mat"), py::arg("name"), py::arg("symmetry") = 0);
+//    py::class_<MatrixFactory, std::shared_ptr<MatrixFactory>>(m, "MatrixFactory", "Creates Matrix objects")
+//        .def("create_matrix", create_shared_matrix(&MatrixFactory::create_shared_matrix),
+//             "Returns a new matrix object with default dimensions", py::arg("symmetry") = 0)
+ //       .def("create_matrix", create_shared_matrix_name(&MatrixFactory::create_shared_matrix),
+//             "Returns a new Matrix object named name with default dimensions", 
+//             py::arg("mat"), py::arg("name"), py::arg("symmetry") = 0);
 
     py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(m, "CdSalcList", "Class for generating symmetry adapted linear combinations")
         .def("print_out", &CdSalcList::print, "Print the SALC")
@@ -792,22 +792,22 @@ void export_mints(py::module& m)
 
 
         // Two-electron MO and transformers
-        .def("mo_eri", eri(&MintsHelper::mo_eri), "MO ERI Integrals. Pass appropriate MO coefficients", 
-             py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("mo_erf_eri", erf(&MintsHelper::mo_erf_eri), "MO ERFC Omega Integrals", 
-             py::arg("omega"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("mo_f12", &MintsHelper::mo_f12, "MO F12 Integrals",
-             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("mo_f12_squared", &MintsHelper::mo_f12_squared, "MO F12 squared integrals",
-             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("mo_f12g12", &MintsHelper::mo_f12g12, "MO F12G12 integrals",
-             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("mo_f12_double_commutator", &MintsHelper::mo_f12_double_commutator, "MO F12 double commutator integrals",
-             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("mo_spin_eri", &MintsHelper::mo_spin_eri, "Symmetric MO Spin ERI Integrals", py::arg("C1"), py::arg("C2"))
-        .def("mo_transform", &MintsHelper::mo_transform, "N^5 ao to mo transfrom, in memory",
-             py::arg("Iso"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
-        .def("set_rel_basisset", &MintsHelper::set_rel_basisset, "Sets the relativistic basis set", py::arg("rel_basis"))
+//        .def("mo_eri", eri(&MintsHelper::mo_eri), "MO ERI Integrals. Pass appropriate MO coefficients", 
+//             py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+//        .def("mo_erf_eri", erf(&MintsHelper::mo_erf_eri), "MO ERFC Omega Integrals", 
+//             py::arg("omega"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+//        .def("mo_f12", &MintsHelper::mo_f12, "MO F12 Integrals",
+//             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+//        .def("mo_f12_squared", &MintsHelper::mo_f12_squared, "MO F12 squared integrals",
+//             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+//        .def("mo_f12g12", &MintsHelper::mo_f12g12, "MO F12G12 integrals",
+//             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+//        .def("mo_f12_double_commutator", &MintsHelper::mo_f12_double_commutator, "MO F12 double commutator integrals",
+//             py::arg("corr"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+//        .def("mo_spin_eri", &MintsHelper::mo_spin_eri, "Symmetric MO Spin ERI Integrals", py::arg("C1"), py::arg("C2"))
+//        .def("mo_transform", &MintsHelper::mo_transform, "N^5 ao to mo transfrom, in memory",
+//             py::arg("Iso"), py::arg("C1"), py::arg("C2"), py::arg("C3"), py::arg("C4"))
+//        .def("set_rel_basisset", &MintsHelper::set_rel_basisset, "Sets the relativistic basis set", py::arg("rel_basis"))
 
         .def("play", &MintsHelper::play, "play function");  //???
 
@@ -1168,11 +1168,11 @@ void export_mints(py::module& m)
         .def(py::init<std::shared_ptr<Wavefunction>>())
         .def("write", &FCHKWriter::write, "Write wavefunction information to file", py::arg("filename"));
 
-    py::class_<MoldenWriter, std::shared_ptr<MoldenWriter>>(m, "MoldenWriter", "Writes wavefunction information in molden format")
-        .def(py::init<std::shared_ptr<Wavefunction>>())
-        .def("write", &MoldenWriter::write, "Writes wavefunction information in molden format",
-             py::arg("filename"),  py::arg("Ca"),  py::arg("Cb"),  py::arg("Ea"),  py::arg("Eb"),
-             py::arg("OccA"),   py::arg("OccB"), py::arg("dovirtual")); 
+//    py::class_<MoldenWriter, std::shared_ptr<MoldenWriter>>(m, "MoldenWriter", "Writes wavefunction information in molden format")
+//        .def(py::init<std::shared_ptr<Wavefunction>>())
+//        .def("write", &MoldenWriter::write, "Writes wavefunction information in molden format",
+//             py::arg("filename"),  py::arg("Ca"),  py::arg("Cb"),  py::arg("Ea"),  py::arg("Eb"),
+//             py::arg("OccA"),   py::arg("OccB"), py::arg("dovirtual")); 
 
     py::class_<NBOWriter, std::shared_ptr<NBOWriter>>(m, "NBOWriter", "The Natural Bond Orbital Writer")
         .def(py::init<std::shared_ptr<Wavefunction>>())

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -549,7 +549,7 @@ void export_mints(py::module& m)
         //            def("normalize_shell", &GaussianShell::normalize_shell, "docstring").
         def("exp", &GaussianShell::exp, "Returns the exponent of the given primitive", py::arg("prim"))
         .def("original_coef", &GaussianShell::original_coef, "Return unnormalized coefficient of the pi'th primitive", py::arg("pi"))
-        .def("erd_coef", &GaussianShell::erd_coef, "docstring")
+        .def("erd_coef", &GaussianShell::erd_coef, "Return ERD normalized coefficient of pi'th primitive", py::arg("pi"))
         .def("coef", &GaussianShell::coef, "Return coefficient of the pi'th primitive", py::arg("pi"));
 
     py::enum_<PrimitiveType>(m, "PrimitiveType", "May be Normalized or Unnormalized")
@@ -783,7 +783,7 @@ void export_mints(py::module& m)
         .def("ao_f12", normal_f12(&MintsHelper::ao_f12), "AO F12 integrals", py::arg("corr"))
         .def("ao_f12", normal_f122(&MintsHelper::ao_f12), "AO F12 integrals", 
               py::arg("corr"), py::arg("bs1"), py::arg("bs2"), py::arg("bs3"), py::arg("bs4"))
-        .def("ao_f12_scaled", normal_f12(&MintsHelper::ao_f12_scaled), "docstring") //doc's in C++ code seem incorrect, labelled as MO..
+        .def("ao_f12_scaled", normal_f12(&MintsHelper::ao_f12_scaled), "docstring") //doc's in C++ code seem incorrect, labelled as MO
         .def("ao_f12_scaled", normal_f122(&MintsHelper::ao_f12_scaled), "docstring")
         .def("ao_f12_squared", normal_f12(&MintsHelper::ao_f12_squared), "docstring")
         .def("ao_f12_squared", normal_f122(&MintsHelper::ao_f12_squared), "docstring")


### PR DESCRIPTION
## Description
99% of the docstrings in export_mints.cc are now composed, with appropriate py::arg's. There are a few docstrings remaining, which were left either because I couldn't figure out what to write or they lacked C++ documentation.

Psi4 compiled and psi4 --test finished successfully after these changes.
## Todos
- [ ] Fill in last remaining docstrings


## Questions
-  Psi4 does not compile when I supply the MatrixFactory function's py::args, and I could not figure out why. Can someone more knowledgeable take a look at this?


## Status
- [ ] Ready to go
